### PR TITLE
Rename links title to label

### DIFF
--- a/app/components/short_link_form_component.html.erb
+++ b/app/components/short_link_form_component.html.erb
@@ -2,8 +2,8 @@
   <%= form_with model: @link, url: links_path, local: true do |form| %>
     <div class="flex flex-col space-y-6">
       <div class="flex flex-col space-y-2 w-3/6">
-        <%= form.label :title, "Title:" %>
-        <%= form.text_field :title, class: "rounded-lg", placeholder: "My website" %>
+        <%= form.label :label, "Label:" %>
+        <%= form.text_field :label, class: "rounded-lg", placeholder: "My website" %>
       </div>
       <div class="flex flex-col space-y-2 w-5/6">
         <%= form.label :target_url, "URL:" %>

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -6,10 +6,7 @@ class LinksController < ApplicationController
   def show
     @link = ShortCodeCacheRead.new(params[:short_code]).call
 
-    if @link.nil?
-      render :not_found
-      return
-    end
+    render :not_found and return if @link.nil?
 
     @current_user = current_user
     @short_url_full = @link.full_short_url(request)
@@ -67,7 +64,7 @@ class LinksController < ApplicationController
   private
 
   def link_params
-    params.require(:link).permit(:title, :target_url)
+    params.require(:link).permit(:label, :target_url)
   end
 
   def build_link(link_params)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -9,7 +9,7 @@ class Link < ApplicationRecord
   belongs_to :user, optional: true
   has_many :link_clicks, dependent: :destroy
 
-  validates :title, presence: true
+  validates :label, presence: true
   validates :short_code, presence: true
   validates :short_code, uniqueness: true
   validates :target_url, presence: true

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -36,8 +36,8 @@
     <div class="w-2/3 border-t border-gray-100">
       <dl class="divide-y divide-gray-100">
         <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
-          <dt class="text-sm font-medium leading-6 text-gray-900">Title</dt>
-          <dd class="mt-1 text-lg leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= @link.title %></dd>
+          <dt class="text-sm font-medium leading-6 text-gray-900">Label</dt>
+          <dd class="mt-1 text-lg leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= @link.label %></dd>
         </div>
         <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
           <dt class="text-sm font-medium leading-6 text-gray-900">Target URL (Original URL)</dt>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -16,7 +16,7 @@
         <table class="min-w-full divide-y divide-gray-300">
           <thead>
             <tr>
-              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0">Title</th>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0">Label</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Short Url</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Target Url</th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Total Clicks</th>
@@ -29,7 +29,7 @@
             <% @user.links.each do |link| %>
               <tr>
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0">
-                  <%= link_to link.title, short_code_links_path(link.short_code), class: "text-indigo-600"  %>
+                  <%= link_to link.label, short_code_links_path(link.short_code), class: "text-indigo-600"  %>
                 </td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= link.full_short_url(request) %></td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= link.target_url %></td>

--- a/db/migrate/20240930034955_rename_title_to_label_in_links.rb
+++ b/db/migrate/20240930034955_rename_title_to_label_in_links.rb
@@ -1,0 +1,5 @@
+class RenameTitleToLabelInLinks < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :links, :title, :label
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_13_094603) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_30_034955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,7 +32,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_094603) do
   end
 
   create_table "links", force: :cascade do |t|
-    t.string "title"
+    t.string "label"
     t.string "target_url"
     t.string "short_code"
     t.datetime "created_at", null: false

--- a/spec/components/short_link_form_component_spec.rb
+++ b/spec/components/short_link_form_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ShortLinkFormComponent, type: :component do
 
   it 'renders the create short link form' do
     render_inline(described_class.new(link:))
-    expect(page).to have_text 'Title'
+    expect(page).to have_text 'Label'
     expect(page).to have_text 'URL'
   end
 end

--- a/spec/controllers/links_spec.rb
+++ b/spec/controllers/links_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe LinksController, type: :controller do
   end
 
   describe 'POST #create' do
-    let(:valid_link_params) { { link: { title: 'Jibone Blog', target_url: 'https://jshamsul.com' } } }
-    let(:invalid_url_params) { { link: { title: 'Wrong', target_url: 'ht@@tp:/huhu' } } }
+    let(:valid_link_params) { { link: { label: 'Jibone Blog', target_url: 'https://jshamsul.com' } } }
+    let(:invalid_url_params) { { link: { label: 'Wrong', target_url: 'ht@@tp:/huhu' } } }
 
     context 'with valid attribute' do
       it 'creates a shorten url redirect to shorten link page' do
@@ -108,7 +108,7 @@ RSpec.describe LinksController, type: :controller do
   describe 'GET #redirect' do
     context 'when a valid short code is provided' do
       it 'redirects to the external URL' do
-        new_link = create(:link, title: 'jibone', target_url: 'https://jshamsul.com')
+        new_link = create(:link, label: 'jibone', target_url: 'https://jshamsul.com')
 
         get :redirect, params: { short_code: new_link.short_code }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
   end
 
   factory :link do
-    title { "Jibone's blog" }
+    label { "Jibone's blog" }
     target_url { "https://jshamsul.com" }
     short_code { "qwerty" }
   end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Link, type: :model do
   describe 'validations' do
-    it { should validate_presence_of(:title) }
+    it { should validate_presence_of(:label) }
     it { should validate_presence_of(:target_url) }
     it { should validate_presence_of(:short_code) }
     it { should validate_uniqueness_of(:short_code) }


### PR DESCRIPTION
This PR rename the links title to label.

We want to fetch the link's title from the link's title tag. We do not want to remove the current data. This still gives users to label their links.